### PR TITLE
fix: use bignumber for ahp format

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "apexcharts": "^3.37.1",
     "autoprefixer": "^10.4.14",
     "axios": "^1.3.2",
+    "bignumber.js": "^9.3.0",
     "buffer": "^6.0.3",
     "build": "^0.1.4",
     "cross-fetch": "^3.1.5",

--- a/src/components/dynamic/ArrayCoinElement.vue
+++ b/src/components/dynamic/ArrayCoinElement.vue
@@ -10,7 +10,7 @@ const format = useFormatter();
 </script>
 <template>
   <div>
-    {{ format.formatTokens(value, true, '0,0.[000000000000000000]') }}
+    {{ format.formatHP(value, true) }}
   </div>
 </template>
 <script lang="ts">

--- a/src/stores/useFormatter.ts
+++ b/src/stores/useFormatter.ts
@@ -15,6 +15,7 @@ import type { Coin, DenomTrace } from '@/types';
 import { useDashboard } from './useDashboard';
 import type { Asset } from '@ping-pub/chain-registry-client/dist/types';
 import type { Validator } from '@/types';
+import BigNumber from 'bignumber.js';
 
 dayjs.extend(localeData);
 dayjs.extend(duration);
@@ -307,6 +308,25 @@ export const useFormatter = defineStore('formatter', {
     ): string {
       if (!tokens) return '';
       return tokens.map((x) => this.formatToken(x, withDenom, fmt)).join(', ');
+    },
+    // used to format ahp unit to hp, do not truncate decimal
+    formatHP(
+      tokens?: { denom: string; amount: string }[],
+      withDenom = true
+    ): string {
+      const token = tokens?.at(0);
+      const unit = 'HP';
+      if (!token || !token.amount || !token.denom) {
+        return '-';
+      }
+
+      let amount = new BigNumber(token.amount);
+
+      if (token.denom.toLowerCase() === 'ahp') {
+        amount = amount.dividedBy(new BigNumber(10).pow(18));
+      }
+
+      return withDenom ? `${amount.toFormat()} ${unit}` : amount.toFormat();
     },
     calculateBondedRatio(
       pool: { bonded_tokens: string; not_bonded_tokens: string } | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -3300,6 +3300,11 @@ bignumber.js@^9.1.2:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
+bignumber.js@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.0.tgz#bdba7e2a4c1a2eba08290e8dcad4f36393c92acd"
+  integrity sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"


### PR DESCRIPTION
javascript's number have only 16 digits precision. use bignumber.js for 18 digits ahp unit.