### PR TITLE
fix: handle when we fetch the first genesis block

### DIFF
--- a/src/modules/[chain]/block/index.vue
+++ b/src/modules/[chain]/block/index.vue
@@ -24,8 +24,9 @@ const list = computed(() => {
 
 const pageSize = 20;
 const onPageChange = (page: number) => {
+  const minHeight = Number(base.latest.block.header.height) - page * pageSize;
   base.fetchBlocks(
-    Number(base.latest.block.header.height) - page * pageSize,
+    minHeight < 0 ? 0: minHeight,
     Number(base.latest.block.header.height) - (page - 1) * pageSize
   );
 };


### PR DESCRIPTION
Currently, we cannot fetch the genesis block page as its minHeight passed as negative value(unless the last page has 20 blocks).